### PR TITLE
Add GCP Cloud Run deployment: containerization, auth, config editor, and scheduled updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Git
+.git
+.gitignore
+
+# Secrets and local config (never bake credentials into the image)
+.env
+config.json
+
+# Python byte-code and caches
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+.mypy_cache/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local transaction cache (lives in GCS in cloud deployments)
+~/.ry-n-shres-budget-app/
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+
+# macOS
+.DS_Store
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# Test output
+htmlcov/
+.coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# ── System dependencies ────────────────────────────────────────────────────────
+# build-essential is needed for compiling any C-extension packages.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python dependencies ────────────────────────────────────────────────────────
+COPY cloud_requirements.txt .
+RUN pip install --no-cache-dir -r cloud_requirements.txt
+
+# ── Application code ───────────────────────────────────────────────────────────
+COPY . .
+
+# ── Streamlit configuration ────────────────────────────────────────────────────
+# These are read by Streamlit at startup. Setting them here avoids needing
+# a streamlit/config.toml file inside the container.
+ENV STREAMLIT_SERVER_PORT=8080
+ENV STREAMLIT_SERVER_ADDRESS=0.0.0.0
+ENV STREAMLIT_SERVER_HEADLESS=true
+ENV STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
+ENV STREAMLIT_SERVER_ENABLE_CORS=false
+# Raise the default max upload limit in case large CSVs are ever uploaded.
+ENV STREAMLIT_SERVER_MAX_UPLOAD_SIZE=200
+
+# ── Runtime ────────────────────────────────────────────────────────────────────
+EXPOSE 8080
+
+CMD ["streamlit", "run", "scripts/st_dashboard.py", \
+     "--server.port=8080", \
+     "--server.address=0.0.0.0", \
+     "--server.headless=true"]

--- a/cloud/deploy.sh
+++ b/cloud/deploy.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# cloud/deploy.sh — Build image and deploy to Cloud Run
+#
+# Run this after cloud/setup.sh for the first deploy, and whenever you update
+# the application code.
+#
+# Usage:
+#   export PROJECT_ID=my-gcp-project
+#   bash cloud/deploy.sh
+#
+# Optional overrides (all have sensible defaults):
+#   REGION, BUCKET_NAME, SERVICE_ACCOUNT_NAME, REPOSITORY,
+#   SERVICE_NAME, JOB_NAME, SCHEDULER_SCHEDULE
+
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+PROJECT_ID="${PROJECT_ID:?Set PROJECT_ID}"
+REGION="${REGION:-us-central1}"
+BUCKET_NAME="${BUCKET_NAME:-${PROJECT_ID}-budget-data}"
+SERVICE_ACCOUNT_NAME="${SERVICE_ACCOUNT_NAME:-budget-app-sa}"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+REPOSITORY="${REPOSITORY:-budget-app}"
+SERVICE_NAME="${SERVICE_NAME:-budget-dashboard}"
+JOB_NAME="${JOB_NAME:-budget-update-transactions}"
+
+# Cron schedule for the background transaction update job (default: 6 AM daily).
+SCHEDULER_SCHEDULE="${SCHEDULER_SCHEDULE:-0 6 * * *}"
+
+IMAGE_URL="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/${SERVICE_NAME}"
+
+echo "=== Budget App — Deploy ==="
+echo "  Project  : $PROJECT_ID"
+echo "  Region   : $REGION"
+echo "  Image    : $IMAGE_URL"
+echo ""
+
+# ── Authenticate Docker with Artifact Registry ─────────────────────────────────
+echo "--- Configuring Docker auth..."
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+# ── Build and push image ───────────────────────────────────────────────────────
+echo "--- Building Docker image..."
+docker build --platform linux/amd64 -t "$IMAGE_URL" .
+
+echo "--- Pushing image to Artifact Registry..."
+docker push "$IMAGE_URL"
+
+# ── Substitute variables in YAML templates ────────────────────────────────────
+_render_yaml() {
+    local template="$1"
+    sed \
+        -e "s|PROJECT_ID|${PROJECT_ID}|g" \
+        -e "s|REGION|${REGION}|g" \
+        -e "s|IMAGE_URL|${IMAGE_URL}|g" \
+        -e "s|BUCKET_NAME|${BUCKET_NAME}|g" \
+        -e "s|SERVICE_ACCOUNT|${SERVICE_ACCOUNT}|g" \
+        "$template"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Deploy Cloud Run service (dashboard) ───────────────────────────────────────
+echo "--- Deploying Cloud Run service '$SERVICE_NAME'..."
+_render_yaml "$SCRIPT_DIR/service.yaml" | \
+    gcloud run services replace - \
+        --region="$REGION" \
+        --project="$PROJECT_ID"
+
+# Allow unauthenticated requests — the app enforces its own password auth.
+gcloud run services add-iam-policy-binding "$SERVICE_NAME" \
+    --region="$REGION" \
+    --project="$PROJECT_ID" \
+    --member="allUsers" \
+    --role="roles/run.invoker"
+
+# ── Deploy Cloud Run Job (background update) ───────────────────────────────────
+echo "--- Deploying Cloud Run Job '$JOB_NAME'..."
+_render_yaml "$SCRIPT_DIR/job.yaml" | \
+    gcloud run jobs replace - \
+        --region="$REGION" \
+        --project="$PROJECT_ID"
+
+# ── Cloud Scheduler trigger for the update job ─────────────────────────────────
+echo "--- Setting up Cloud Scheduler (schedule: '$SCHEDULER_SCHEDULE')..."
+
+# Build the job execution URL from the job name and region.
+JOB_URL="https://${REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${JOB_NAME}:run"
+
+SCHEDULER_JOB_NAME="budget-update-transactions-trigger"
+if gcloud scheduler jobs describe "$SCHEDULER_JOB_NAME" \
+        --location="$REGION" --project="$PROJECT_ID" &>/dev/null; then
+    echo "    Scheduler job already exists — updating schedule..."
+    gcloud scheduler jobs update http "$SCHEDULER_JOB_NAME" \
+        --location="$REGION" \
+        --project="$PROJECT_ID" \
+        --schedule="$SCHEDULER_SCHEDULE" \
+        --uri="$JOB_URL" \
+        --http-method=POST \
+        --oauth-service-account-email="$SERVICE_ACCOUNT" \
+        --quiet
+else
+    gcloud scheduler jobs create http "$SCHEDULER_JOB_NAME" \
+        --location="$REGION" \
+        --project="$PROJECT_ID" \
+        --schedule="$SCHEDULER_SCHEDULE" \
+        --uri="$JOB_URL" \
+        --http-method=POST \
+        --oauth-service-account-email="$SERVICE_ACCOUNT" \
+        --quiet
+fi
+
+# Grant the SA permission to trigger Cloud Run Jobs.
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:$SERVICE_ACCOUNT" \
+    --role="roles/run.invoker" \
+    --quiet
+
+# ── Print the service URL ──────────────────────────────────────────────────────
+SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \
+    --region="$REGION" \
+    --project="$PROJECT_ID" \
+    --format="value(status.url)")
+
+echo ""
+echo "=== Deploy complete! ==="
+echo ""
+echo "  Dashboard URL : $SERVICE_URL"
+echo "  Update job    : $JOB_NAME (runs at: $SCHEDULER_SCHEDULE)"
+echo ""
+echo "To trigger the update job immediately:"
+echo "  gcloud run jobs execute $JOB_NAME --region=$REGION --project=$PROJECT_ID"
+echo ""
+echo "To view dashboard logs:"
+echo "  gcloud run services logs read $SERVICE_NAME --region=$REGION --project=$PROJECT_ID"
+echo ""

--- a/cloud/job.yaml
+++ b/cloud/job.yaml
@@ -1,0 +1,60 @@
+# Cloud Run Job definition — nightly transaction update
+#
+# This job runs scripts/update_transactions.py on a schedule set by
+# Cloud Scheduler (configured in deploy.sh).  It mounts the same GCS bucket
+# as the dashboard service so both share the same transaction CSV.
+#
+# Variables substituted by deploy.sh:
+#   PROJECT_ID, REGION, IMAGE_URL, BUCKET_NAME, SERVICE_ACCOUNT
+
+apiVersion: run.googleapis.com/v1
+kind: Job
+metadata:
+  name: budget-update-transactions
+  labels:
+    cloud.googleapis.com/location: REGION
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/execution-environment: gen2
+    spec:
+      taskCount: 1
+      template:
+        spec:
+          serviceAccountName: SERVICE_ACCOUNT
+          maxRetries: 2
+          timeoutSeconds: "300"
+
+          # ── GCS volume ───────────────────────────────────────────────────
+          volumes:
+            - name: budget-data
+              csi:
+                driver: gcsfuse.run.googleapis.com
+                readOnly: false
+                volumeAttributes:
+                  bucketName: BUCKET_NAME
+                  mountOptions: "implicit-dirs,file-mode=0600,dir-mode=0700"
+
+          containers:
+            - image: IMAGE_URL
+              command: ["python", "scripts/update_transactions.py"]
+
+              volumeMounts:
+                - name: budget-data
+                  mountPath: /root/.ry-n-shres-budget-app
+
+              env:
+                - name: CONFIG_PATH
+                  value: /root/.ry-n-shres-budget-app/config.json
+
+                - name: SIMPLEFIN_AUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: simplefin-auth
+                      key: latest
+
+              resources:
+                limits:
+                  memory: 512Mi
+                  cpu: "1"

--- a/cloud/service.yaml
+++ b/cloud/service.yaml
@@ -13,16 +13,18 @@ metadata:
   name: budget-dashboard
   labels:
     cloud.googleapis.com/location: REGION
+  annotations:
+    # Scaling policy lives on the Service, not the Revision template.
+    # Keep one instance warm to avoid cold-start latency for a personal app.
+    # Set minScale to "0" to scale fully to zero (saves cost, slower first load).
+    run.googleapis.com/minScale: "1"
+    run.googleapis.com/maxScale: "2"
 spec:
   template:
     metadata:
       annotations:
         # gen2 execution environment is required for Cloud Storage FUSE mounts.
         run.googleapis.com/execution-environment: gen2
-        # Keep one instance warm to avoid cold-start latency for a personal app.
-        # Remove or set to "0" to scale fully to zero (saves cost, slower first load).
-        run.googleapis.com/minScale: "1"
-        run.googleapis.com/maxScale: "2"
     spec:
       serviceAccountName: SERVICE_ACCOUNT
 

--- a/cloud/service.yaml
+++ b/cloud/service.yaml
@@ -51,6 +51,8 @@ spec:
           # ── Environment variables ─────────────────────────────────────────
           env:
             # Tell the app where config.json lives (inside the mounted bucket).
+            # Read by src/utils.get_config_path(); falls back to ./config.json
+            # for local dev when this variable is not set.
             - name: CONFIG_PATH
               value: /root/.ry-n-shres-budget-app/config.json
 

--- a/cloud/service.yaml
+++ b/cloud/service.yaml
@@ -1,0 +1,79 @@
+# Cloud Run service definition — budget dashboard
+#
+# Variables to substitute before applying (done automatically by deploy.sh):
+#   PROJECT_ID   — your GCP project ID
+#   REGION       — Cloud Run region, e.g. us-central1
+#   IMAGE_URL    — full Artifact Registry image URL
+#   BUCKET_NAME  — GCS bucket for persistent data
+#   SERVICE_ACCOUNT — service-account email
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: budget-dashboard
+  labels:
+    cloud.googleapis.com/location: REGION
+spec:
+  template:
+    metadata:
+      annotations:
+        # gen2 execution environment is required for Cloud Storage FUSE mounts.
+        run.googleapis.com/execution-environment: gen2
+        # Keep one instance warm to avoid cold-start latency for a personal app.
+        # Remove or set to "0" to scale fully to zero (saves cost, slower first load).
+        run.googleapis.com/minScale: "1"
+        run.googleapis.com/maxScale: "2"
+    spec:
+      serviceAccountName: SERVICE_ACCOUNT
+
+      # ── GCS volume (transactions CSV + config.json live here) ──────────────
+      volumes:
+        - name: budget-data
+          csi:
+            driver: gcsfuse.run.googleapis.com
+            readOnly: false
+            volumeAttributes:
+              bucketName: BUCKET_NAME
+              # Improve throughput for the CSV reads/writes.
+              mountOptions: "implicit-dirs,file-mode=0600,dir-mode=0700"
+
+      containers:
+        - image: IMAGE_URL
+          ports:
+            - containerPort: 8080
+
+          # ── Volume mount ──────────────────────────────────────────────────
+          volumeMounts:
+            - name: budget-data
+              # Must match the hardcoded data dir in src/transactions/selection.py
+              mountPath: /root/.ry-n-shres-budget-app
+
+          # ── Environment variables ─────────────────────────────────────────
+          env:
+            # Tell the app where config.json lives (inside the mounted bucket).
+            - name: CONFIG_PATH
+              value: /root/.ry-n-shres-budget-app/config.json
+
+            # Dashboard password — stored in Secret Manager.
+            - name: APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: budget-app-password
+                  key: latest
+
+            # SimpleFin credentials — stored in Secret Manager.
+            - name: SIMPLEFIN_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: simplefin-auth
+                  key: latest
+
+          # ── Resource limits ───────────────────────────────────────────────
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: "1"
+
+  traffic:
+    - percent: 100
+      latestRevision: true

--- a/cloud/setup.sh
+++ b/cloud/setup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# cloud/setup.sh — One-time GCP infrastructure setup
+#
+# Run this once before your first deployment.  It is safe to re-run
+# (all commands are idempotent).
+#
+# Prerequisites:
+#   - gcloud CLI installed and authenticated  (gcloud auth login)
+#   - Billing enabled on the project
+#   - The following APIs will be enabled automatically by this script
+#
+# Usage:
+#   export PROJECT_ID=my-gcp-project
+#   export SIMPLEFIN_AUTH="https://..."    # your SimpleFin bridge URL
+#   export APP_PASSWORD="your-password"   # dashboard login password
+#   bash cloud/setup.sh
+
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+PROJECT_ID="${PROJECT_ID:?Set PROJECT_ID}"
+REGION="${REGION:-us-central1}"
+BUCKET_NAME="${BUCKET_NAME:-${PROJECT_ID}-budget-data}"
+SERVICE_ACCOUNT_NAME="${SERVICE_ACCOUNT_NAME:-budget-app-sa}"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+REPOSITORY="${REPOSITORY:-budget-app}"
+
+SIMPLEFIN_AUTH="${SIMPLEFIN_AUTH:?Set SIMPLEFIN_AUTH}"
+APP_PASSWORD="${APP_PASSWORD:?Set APP_PASSWORD}"
+
+echo "=== Budget App — One-time GCP Setup ==="
+echo "  Project : $PROJECT_ID"
+echo "  Region  : $REGION"
+echo "  Bucket  : $BUCKET_NAME"
+echo ""
+
+# ── Enable required APIs ───────────────────────────────────────────────────────
+echo "--- Enabling APIs..."
+gcloud services enable \
+    run.googleapis.com \
+    artifactregistry.googleapis.com \
+    secretmanager.googleapis.com \
+    cloudscheduler.googleapis.com \
+    storage.googleapis.com \
+    --project "$PROJECT_ID"
+
+# ── Artifact Registry repository ──────────────────────────────────────────────
+echo "--- Creating Artifact Registry repository..."
+gcloud artifacts repositories create "$REPOSITORY" \
+    --repository-format=docker \
+    --location="$REGION" \
+    --project="$PROJECT_ID" \
+    --quiet \
+    2>/dev/null || echo "    (repository already exists — skipping)"
+
+# ── GCS bucket for persistent data ────────────────────────────────────────────
+echo "--- Creating GCS bucket gs://$BUCKET_NAME ..."
+gcloud storage buckets create "gs://$BUCKET_NAME" \
+    --project="$PROJECT_ID" \
+    --location="$REGION" \
+    --uniform-bucket-level-access \
+    2>/dev/null || echo "    (bucket already exists — skipping)"
+
+# ── Service account ────────────────────────────────────────────────────────────
+echo "--- Creating service account $SERVICE_ACCOUNT ..."
+gcloud iam service-accounts create "$SERVICE_ACCOUNT_NAME" \
+    --display-name="Budget App Service Account" \
+    --project="$PROJECT_ID" \
+    2>/dev/null || echo "    (service account already exists — skipping)"
+
+# Grant Storage Object Admin so the SA can read/write the bucket.
+gcloud storage buckets add-iam-policy-binding "gs://$BUCKET_NAME" \
+    --member="serviceAccount:$SERVICE_ACCOUNT" \
+    --role="roles/storage.objectAdmin"
+
+# Grant Secret Manager Secret Accessor so the SA can read secrets at runtime.
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:$SERVICE_ACCOUNT" \
+    --role="roles/secretmanager.secretAccessor"
+
+# ── Secrets ────────────────────────────────────────────────────────────────────
+echo "--- Storing secrets in Secret Manager..."
+
+store_secret() {
+    local name="$1"
+    local value="$2"
+    if gcloud secrets describe "$name" --project="$PROJECT_ID" &>/dev/null; then
+        echo "    $name exists — adding new version..."
+        echo -n "$value" | gcloud secrets versions add "$name" \
+            --data-file=- --project="$PROJECT_ID"
+    else
+        echo "    Creating $name..."
+        echo -n "$value" | gcloud secrets create "$name" \
+            --data-file=- --project="$PROJECT_ID" --replication-policy="automatic"
+    fi
+}
+
+store_secret "simplefin-auth"       "$SIMPLEFIN_AUTH"
+store_secret "budget-app-password"  "$APP_PASSWORD"
+
+echo ""
+echo "=== Setup complete! ==="
+echo ""
+echo "Next steps:"
+echo "  1. Upload your config.json to the bucket:"
+echo "     gcloud storage cp config.json gs://$BUCKET_NAME/config.json"
+echo ""
+echo "  2. Run the deploy script to build and deploy the app:"
+echo "     bash cloud/deploy.sh"
+echo ""

--- a/cloud_requirements.txt
+++ b/cloud_requirements.txt
@@ -1,0 +1,30 @@
+# Cloud-optimized requirements for the budget dashboard.
+# Replaces dashboard_requirements.txt for Docker builds — strips macOS-only
+# packages (appnope, etc.) and Jupyter tooling that is unused in the container.
+
+# Core data
+numpy>=1.21.0,<2.0.0
+pandas>=1.3.0,<2.0.0
+python-dateutil>=2.8.2
+pytz>=2021.1
+six>=1.16.0
+
+# Dashboard
+streamlit>=1.28.0,<2.0.0
+altair>=4.2.0,<5.0.0
+pydeck>=0.7.0
+
+# Financial integrations
+plaid-python>=8.6.0
+requests>=2.26.0
+urllib3>=1.26.7
+
+# Config / env
+python-dotenv>=0.19.0
+toml>=0.10.2
+
+# Optional: local ML classification
+# Uncomment the lines below and rebuild if you want use_local_categorization=true.
+# Note: adds ~3 GB to the image and significantly increases cold-start time.
+# torch>=1.9.0
+# transformers>=4.12.0

--- a/scripts/st_dashboard.py
+++ b/scripts/st_dashboard.py
@@ -15,10 +15,10 @@ sys.path.append(os.getcwd())
 load_dotenv()
 
 from src.budget import Budget
-from src.transactions.selection import maybe_pull_latest_transactions
+from src.transactions.selection import read_cached_transactions
 from src.transactions.user_modifications import transform_pipeline
 from src.views import top_vendors
-from src.utils import get_config, get_config_path, reload_config
+from src.utils import DEFAULT_CONFIG, get_config, get_config_path, reload_config
 
 st.set_page_config(initial_sidebar_state="collapsed")
 
@@ -60,8 +60,9 @@ def check_password() -> bool:
 
 @st.cache_data
 def get_transaction_data():
-    all_transactions_df = maybe_pull_latest_transactions()
+    all_transactions_df = read_cached_transactions()
 
+    # Fix for Streamlit Cache issues
     for col in ["payment_meta", "location"]:
         if col in all_transactions_df.columns:
             all_transactions_df = all_transactions_df.drop(col, axis=1)
@@ -87,23 +88,11 @@ def _render_config_editor() -> None:
             with open(config_path) as f:
                 current_content = f.read()
         except FileNotFoundError:
-            current_content = json.dumps({
-                "settings": {
-                    "use_local_categorization": False,
-                    "transformations": [
-                        "add_month", "add_cat_1", "add_cat_2", "important_cols"
-                    ],
-                    "remove_transactions": [],
-                    "custom_category_map": {},
-                    "category_renaming_map": {},
-                    "default_categories_to_ignore": ["Income"],
-                },
-                "budget": {
-                    "total": 5000,
-                    "period": {"default": "month"},
-                    "categories": {},
-                },
-            }, indent=2)
+            st.warning(
+                f"Config file not found at `{config_path}`. "
+                "Showing defaults — click **Save** to create it."
+            )
+            current_content = json.dumps(DEFAULT_CONFIG, indent=2)
 
         new_content = st.text_area(
             "config.json",
@@ -403,6 +392,16 @@ def main():
             Connection error: %s
         """
             % e.reason
+        )
+
+    except FileNotFoundError as e:
+        st.error(
+            "No transaction data found. "
+            "Run the update job to fetch your initial transactions:\n\n"
+            "```\n"
+            "gcloud run jobs execute budget-update-transactions --region=<REGION>\n"
+            "```\n\n"
+            f"Details: {e}"
         )
 
     except Exception as e:

--- a/scripts/st_dashboard.py
+++ b/scripts/st_dashboard.py
@@ -15,7 +15,7 @@ sys.path.append(os.getcwd())
 load_dotenv()
 
 from src.budget import Budget
-from src.transactions.selection import read_cached_transactions
+from src.transactions.selection import maybe_pull_latest_transactions, read_cached_transactions
 from src.transactions.user_modifications import transform_pipeline
 from src.views import top_vendors
 from src.utils import DEFAULT_CONFIG, get_config, get_config_path, reload_config
@@ -127,6 +127,26 @@ def _render_config_editor() -> None:
 
 
 # ── Visualization helpers ──────────────────────────────────────────────────────
+
+def _render_refresh_button() -> None:
+    """Sidebar button that pulls the latest transactions on demand.
+
+    In the cloud deployment, data is normally refreshed by the nightly Cloud
+    Run Job.  This button is a convenience escape-hatch — useful when running
+    locally or when you want fresh data without waiting for the scheduler.
+    """
+    st.sidebar.divider()
+    if st.sidebar.button("Fetch latest transactions", use_container_width=True):
+        with st.sidebar.status("Pulling transactions…"):
+            try:
+                maybe_pull_latest_transactions()
+                st.cache_data.clear()
+            except Exception as exc:
+                st.sidebar.error(f"Pull failed: {exc}")
+                return
+        st.sidebar.success("Done — reloading data.")
+        st.rerun()
+
 
 def write_df(df: pd.DataFrame):
     """Write a DataFrame with dollar-formatted amount columns."""
@@ -299,6 +319,7 @@ def main():
         return
 
     _render_config_editor()
+    _render_refresh_button()
 
     try:
         df = get_transaction_data().copy()

--- a/scripts/st_dashboard.py
+++ b/scripts/st_dashboard.py
@@ -1,4 +1,5 @@
 import altair as alt
+import json
 import os
 import pandas as pd
 import streamlit as st
@@ -7,8 +8,6 @@ from typing import List
 
 from datetime import datetime
 from dotenv import load_dotenv
-from plaid.api_client import ApiClient
-from plaid.exceptions import ApiException
 from traceback import format_exc
 from urllib.error import URLError
 
@@ -19,18 +18,50 @@ from src.budget import Budget
 from src.transactions.selection import maybe_pull_latest_transactions
 from src.transactions.user_modifications import transform_pipeline
 from src.views import top_vendors
-from src.utils import get_config
+from src.utils import get_config, get_config_path, reload_config
 
 st.set_page_config(initial_sidebar_state="collapsed")
 
 
-@st.cache(
-    hash_funcs={ApiClient: lambda *args, **kwargs: 0}
-)
+# ── Authentication ─────────────────────────────────────────────────────────────
+
+def check_password() -> bool:
+    """Return True when the user is authenticated (or no password is configured).
+
+    Set the APP_PASSWORD environment variable (via a Cloud Run secret) to
+    enable password protection.  When the variable is absent the app runs
+    without authentication, which is fine for local development.
+    """
+    app_password = os.environ.get("APP_PASSWORD")
+    if not app_password:
+        return True  # No auth configured — local dev mode
+
+    if st.session_state.get("authenticated"):
+        return True
+
+    st.title("Budget Dashboard")
+    st.markdown("Enter the password to continue.")
+
+    with st.form("login_form"):
+        password = st.text_input("Password", type="password")
+        submitted = st.form_submit_button("Login")
+
+    if submitted:
+        if password == app_password:
+            st.session_state["authenticated"] = True
+            st.rerun()
+        else:
+            st.error("Incorrect password. Please try again.")
+
+    return False
+
+
+# ── Data loading ───────────────────────────────────────────────────────────────
+
+@st.cache_data
 def get_transaction_data():
     all_transactions_df = maybe_pull_latest_transactions()
 
-    # Fix for Streamlit Cache issues
     for col in ["payment_meta", "location"]:
         if col in all_transactions_df.columns:
             all_transactions_df = all_transactions_df.drop(col, axis=1)
@@ -39,12 +70,82 @@ def get_transaction_data():
     return all_transactions_df
 
 
+# ── Config editor ──────────────────────────────────────────────────────────────
+
+def _render_config_editor() -> None:
+    """Sidebar panel for editing config.json in-place.
+
+    When running on Cloud Run the config file lives inside the GCS-mounted
+    directory (CONFIG_PATH env var).  Saving here writes directly to GCS so
+    the change is durable across container restarts.
+    """
+    with st.sidebar.expander("Edit Config"):
+        config_path = get_config_path()
+
+        # Load current content (show sample if file not yet created)
+        try:
+            with open(config_path) as f:
+                current_content = f.read()
+        except FileNotFoundError:
+            current_content = json.dumps({
+                "settings": {
+                    "use_local_categorization": False,
+                    "transformations": [
+                        "add_month", "add_cat_1", "add_cat_2", "important_cols"
+                    ],
+                    "remove_transactions": [],
+                    "custom_category_map": {},
+                    "category_renaming_map": {},
+                    "default_categories_to_ignore": ["Income"],
+                },
+                "budget": {
+                    "total": 5000,
+                    "period": {"default": "month"},
+                    "categories": {},
+                },
+            }, indent=2)
+
+        new_content = st.text_area(
+            "config.json",
+            value=current_content,
+            height=420,
+            help=(
+                "Edit your budget configuration here. "
+                "Click **Save** to persist and reload."
+            ),
+        )
+
+        col_save, col_clear = st.columns(2)
+        with col_save:
+            if st.button("Save", type="primary", use_container_width=True):
+                try:
+                    json.loads(new_content)  # Validate JSON before writing
+                    with open(config_path, "w") as f:
+                        f.write(new_content)
+                    reload_config()
+                    st.cache_data.clear()
+                    st.success("Saved! Reload the page to apply changes.")
+                except json.JSONDecodeError as exc:
+                    st.error(f"Invalid JSON — {exc}")
+                except OSError as exc:
+                    st.error(f"Could not write file — {exc}")
+
+        with col_clear:
+            if st.button("Reload Data", use_container_width=True):
+                st.cache_data.clear()
+                reload_config()
+                st.rerun()
+
+
+# ── Visualization helpers ──────────────────────────────────────────────────────
+
 def write_df(df: pd.DataFrame):
-    """Helper function to st.write a DF with amount stylized to dollars"""
+    """Write a DataFrame with dollar-formatted amount columns."""
     st.dataframe(
         df.style.format({
             col_name: "{:,.2f}"
             for col_name in ["amount", "Total Spent"]
+            if col_name in df.columns
         })
     )
 
@@ -204,6 +305,12 @@ def monthly_spending_summary(df: pd.DataFrame, date_inc: DateInc) -> pd.DataFram
 
 
 def main():
+    if not check_password():
+        st.stop()
+        return
+
+    _render_config_editor()
+
     try:
         df = get_transaction_data().copy()
         df = transform_pipeline(df)
@@ -259,7 +366,7 @@ def main():
         curr_date = st.selectbox(
             f"Pick a {date_inc.label}",
             options=available_date_incs,
-            format_func=lambda label: f"{label}      ({df[df[date_inc.key] == label]['amount'].sum():,.2f})"
+            format_func=lambda label: f"{label}      ({df[df[date_inc.key] == label]['amount'].sum():,.2f})"
         )
         single_inc_spending_summary(
             df,
@@ -271,7 +378,6 @@ def main():
         st.write(f"## {date_inc.label}ly Spending History")
         history_df = df_for_certain_categories(df)
         st.write(f"Total Spent: ${history_df['amount'].sum():,.2f}")
-        # st.bar_chart(history_df.groupby(date_inc_key).sum("amount").sort_index(ascending=False))
         st.bar_chart(monthly_spending_summary(history_df, date_inc))
 
         st.write(f"## Most Expensive Single {date_inc.label} Categories")
@@ -293,7 +399,7 @@ def main():
         st.error(
             """
             **This demo requires internet access.**
-    
+
             Connection error: %s
         """
             % e.reason

--- a/scripts/update_transactions.py
+++ b/scripts/update_transactions.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Standalone transaction-update script.
+
+This is the entrypoint for the Cloud Run Job that runs on a schedule (via
+Cloud Scheduler).  It pulls the latest transactions from SimpleFin / Plaid,
+classifies them, and writes the result to the shared GCS-mounted directory
+so the dashboard picks up fresh data on the next page load.
+
+Usage (local):
+    python scripts/update_transactions.py
+
+Usage (Cloud Run Job):
+    Configured automatically via cloud/job.yaml.  The GCS bucket is mounted
+    at /root/.ry-n-shres-budget-app/ so the CSV and pull-info JSON are
+    persisted between runs.
+"""
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from src.transactions.selection import maybe_pull_latest_transactions
+
+
+def main() -> None:
+    print("Starting transaction update...")
+    df = maybe_pull_latest_transactions()
+    print(f"Done. {len(df)} total transactions stored.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/transactions/selection.py
+++ b/src/transactions/selection.py
@@ -31,8 +31,22 @@ empty_transaction_df = pd.DataFrame({
 
 
 def local_transaction_clf_wrapper(df: pd.DataFrame) -> pd.DataFrame:
-    """Wrapping import so we don't have to import torch unless necessary"""
-    from .classification import classify_unknowns
+    """Classify transactions locally using the HuggingFace model.
+
+    The torch + transformers packages are optional (not in cloud_requirements.txt
+    to keep the image small).  If they are not installed we emit a warning and
+    return the dataframe unchanged rather than crashing the app.
+    """
+    try:
+        from .classification import classify_unknowns
+    except ImportError:
+        print(
+            "WARNING: 'transformers' / 'torch' are not installed. "
+            "Skipping local classification (use_local_categorization=true is set "
+            "but will be ignored). Install torch and transformers, or set "
+            "use_local_categorization=false in config.json."
+        )
+        return df
     return classify_unknowns(df)
 
 

--- a/src/transactions/selection.py
+++ b/src/transactions/selection.py
@@ -102,6 +102,30 @@ def get_transaction_method() -> GetTransactionsFnType:
     return METHOD_MAP[method_name]
 
 
+def read_cached_transactions() -> pd.DataFrame:
+    """Read the locally-cached transactions CSV without triggering an API pull.
+
+    In the cloud deployment the dashboard calls this function so it never makes
+    outbound API requests itself.  The nightly Cloud Run Job calls
+    ``maybe_pull_latest_transactions()`` to keep the CSV fresh.
+
+    Raises
+    ------
+    FileNotFoundError
+        When no CSV exists yet.  Run the update job first:
+        ``gcloud run jobs execute budget-update-transactions --region=<REGION>``
+    """
+    try:
+        df = pd.read_csv(EXISTING_TRANSACTIONS_FILE)
+        df["date"] = df["date"].astype(str)
+        return df
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"No transaction data found at {EXISTING_TRANSACTIONS_FILE}. "
+            "Run the update job to fetch initial data."
+        )
+
+
 def maybe_pull_latest_transactions() -> pd.DataFrame:
     config = get_config()
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,7 +12,8 @@ ENV_TO_CONFIG_MAP = {
 }
 
 # Default config used when no config.json exists (e.g. first cloud start).
-_DEFAULT_CONFIG = {
+# Also imported by st_dashboard.py to seed the in-app config editor.
+DEFAULT_CONFIG = {
     "settings": {
         "use_local_categorization": False,
         "transformations": ["add_month", "add_cat_1", "add_cat_2", "important_cols"],
@@ -47,7 +48,7 @@ def get_config() -> dict:
         except FileNotFoundError:
             # First-run in cloud: no config.json yet.  Use defaults and let
             # the user create one via the in-app config editor.
-            _config = _DEFAULT_CONFIG.copy()
+            _config = DEFAULT_CONFIG.copy()
 
         for env_var_name, config_key in ENV_TO_CONFIG_MAP.items():
             if env_var_name in os.environ:

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,23 +11,58 @@ ENV_TO_CONFIG_MAP = {
     "GOOGLE_BUDGET_SPREADSHEET_ID": "budget_spreadsheet_id",
 }
 
+# Default config used when no config.json exists (e.g. first cloud start).
+_DEFAULT_CONFIG = {
+    "settings": {
+        "use_local_categorization": False,
+        "transformations": ["add_month", "add_cat_1", "add_cat_2", "important_cols"],
+        "remove_transactions": [],
+        "custom_category_map": {},
+        "category_renaming_map": {},
+    }
+}
 
 _config = None
 
 
+def get_config_path() -> str:
+    """Returns the path to config.json.
+
+    In cloud deployments set CONFIG_PATH to the file inside the GCS-mounted
+    data directory, e.g. /root/.ry-n-shres-budget-app/config.json.
+    Falls back to ./config.json for local development.
+    """
+    return os.environ.get("CONFIG_PATH", "config.json")
+
+
 def get_config() -> dict:
-    """Returns the Config based on the default Config path"""
+    """Returns the loaded config, reading from disk on first call."""
     global _config
 
     if _config is None:
-        with open('config.json') as config_file:
-            _config = json.load(config_file)
+        config_path = get_config_path()
+        try:
+            with open(config_path) as config_file:
+                _config = json.load(config_file)
+        except FileNotFoundError:
+            # First-run in cloud: no config.json yet.  Use defaults and let
+            # the user create one via the in-app config editor.
+            _config = _DEFAULT_CONFIG.copy()
 
         for env_var_name, config_key in ENV_TO_CONFIG_MAP.items():
             if env_var_name in os.environ:
                 _config[config_key] = os.environ[env_var_name]
 
     return _config
+
+
+def reload_config() -> None:
+    """Clear the in-memory config cache so the next get_config() re-reads disk.
+
+    Call this after saving an updated config.json through the dashboard UI.
+    """
+    global _config
+    _config = None
 
 
 def iso_to_epoch(date_str: str) -> int:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,150 @@
+"""
+Shared fixtures and test infrastructure for the simple-budget-pld test suite.
+
+Plaid-python doesn't build in this environment (and is never exercised by the
+SimpleFin code path we're testing), so we inject a MagicMock for all plaid
+sub-modules before any application module is imported.
+"""
+import sys
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+
+# ── Plaid stub (module-level — runs before any app imports) ───────────────────
+
+def _install_plaid_mock() -> None:
+    """Prevent ImportError when plaid-python is not installed."""
+    if "plaid" in sys.modules:
+        return
+    _stub = MagicMock()
+    for name in [
+        "plaid",
+        "plaid.api",
+        "plaid.api.plaid_api",
+        "plaid.model",
+        "plaid.model.transactions_get_request",
+        "plaid.model.transactions_get_request_options",
+    ]:
+        sys.modules.setdefault(name, _stub)
+
+
+_install_plaid_mock()
+
+
+# ── Shared constant: mock SimpleFin API response ───────────────────────────────
+
+#: Mirrors the shape returned by the SimpleFin Bridge /accounts endpoint.
+SIMPLEFIN_API_RESPONSE = {
+    "accounts": [
+        {
+            "id": "acct_001",
+            "name": "Checking Account",
+            "currency": "USD",
+            "balance": "1234.56",
+            "balance-date": 1704153600,
+            "transactions": [
+                {
+                    "id": "txn_001",
+                    "amount": "-42.50",
+                    "description": "WHOLE FOODS MARKET",
+                    "payee": "Whole Foods",
+                    # 2024-01-02 12:00 UTC — well within any timezone's Jan 2
+                    "transacted_at": 1704196800,
+                },
+                {
+                    "id": "txn_002",
+                    "amount": "-12.99",
+                    "description": "NETFLIX",
+                    "payee": "Netflix",
+                    # 2024-01-01 12:00 UTC
+                    "transacted_at": 1704110400,
+                },
+            ],
+        }
+    ]
+}
+
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def sample_plaid_df() -> pd.DataFrame:
+    """Small DataFrame in Plaid-compatible format with known categories."""
+    return pd.DataFrame({
+        "date": ["2024-01-01", "2024-01-02", "2024-01-15"],
+        "name": ["WHOLE FOODS MARKET", "NETFLIX", "STARBUCKS"],
+        "merchant_name": ["Whole Foods", "Netflix", "Starbucks"],
+        "category": [
+            "['SHOPPING', 'Groceries']",
+            "['BILLS_SUBSCRIPTIONS', 'Streaming']",
+            "['EATING_OUT', 'Coffee']",
+        ],
+        "payment_channel": ["in store", "online", "in store"],
+        "amount": [42.50, 12.99, 5.75],
+    })
+
+
+@pytest.fixture
+def unknown_category_df() -> pd.DataFrame:
+    """Transactions with Unknown categories, as SimpleFin provides them."""
+    return pd.DataFrame({
+        "date": ["2024-01-01", "2024-01-02"],
+        "name": ["WHOLE FOODS MARKET", "NETFLIX"],
+        "merchant_name": ["Whole Foods", "Netflix"],
+        "category": ["['Unknown', 'Unknown']", "['Unknown', 'Unknown']"],
+        "payment_channel": ["in store", "online"],
+        "amount": [42.50, 12.99],
+    })
+
+
+@pytest.fixture
+def simplefin_config() -> dict:
+    """Minimal config dict that selects the SimpleFin transaction source."""
+    return {
+        "simplefin_auth": "user:password",
+        "settings": {
+            "use_local_categorization": False,
+            "transformations": ["add_month", "add_cat_1", "add_cat_2", "important_cols"],
+            "remove_transactions": [],
+            "custom_category_map": {},
+            "category_renaming_map": {},
+        },
+    }
+
+
+@pytest.fixture
+def patched_data_dir(tmp_path, monkeypatch):
+    """Redirect the app's CSV and pull-info paths to an isolated temp directory.
+
+    Returns (transactions_csv_path, pull_info_json_path).
+    """
+    import src.transactions.selection as sel
+
+    txn_file = str(tmp_path / "transactions.csv")
+    pull_info_file = str(tmp_path / "pull_info.json")
+    monkeypatch.setattr(sel, "EXISTING_TRANSACTIONS_FILE", txn_file)
+    monkeypatch.setattr(sel, "TRANSACTIONS_PULL_INFO_FILE", pull_info_file)
+    return txn_file, pull_info_file
+
+
+@pytest.fixture
+def mocked_classifier(monkeypatch):
+    """Inject a mock HuggingFace pipeline so classification tests run without
+    torch/transformers being installed.
+
+    Returns the MagicMock instance that acts as the loaded classifier.
+    Set ``mocked_classifier.return_value`` to control prediction output.
+    """
+    mock_clf_instance = MagicMock()
+    mock_tf = MagicMock()
+    mock_tf.Pipeline = type("MockPipeline", (), {})
+    mock_tf.pipeline = MagicMock(return_value=mock_clf_instance)
+
+    # Replace transformers with our mock so classification.py can be imported.
+    monkeypatch.setitem(sys.modules, "transformers", mock_tf)
+    # Force re-import of the classification module so it picks up the mock.
+    monkeypatch.delitem(sys.modules, "src.transactions.classification", raising=False)
+
+    return mock_clf_instance

--- a/test/test_classification.py
+++ b/test/test_classification.py
@@ -1,0 +1,168 @@
+"""
+Tests for src/transactions/classification.py and the
+local_transaction_clf_wrapper in src/transactions/selection.py
+
+The mocked_classifier fixture (defined in conftest.py) injects a fake
+'transformers' module so these tests run without torch being installed.
+"""
+import sys
+
+import pandas as pd
+import pytest
+
+
+# ── convert_to_category_list_str ─────────────────────────────────────────────
+
+class TestConvertToCategoryListStr:
+    """Unit tests for the HuggingFace-output → Plaid-string converter."""
+
+    def _convert(self, label: str, mocked_classifier) -> str:
+        from src.transactions.classification import convert_to_category_list_str
+        return convert_to_category_list_str({"label": label, "score": 0.9})
+
+    def test_shopping_category(self, mocked_classifier):
+        result = self._convert("Category.SHOPPING_Groceries", mocked_classifier)
+        assert result == "['SHOPPING', 'Groceries']"
+
+    def test_bills_subscriptions_category(self, mocked_classifier):
+        result = self._convert(
+            "Category.BILLS_SUBSCRIPTIONS_Streaming", mocked_classifier
+        )
+        assert result == "['BILLS_SUBSCRIPTIONS', 'Streaming']"
+
+    def test_eating_out_category(self, mocked_classifier):
+        result = self._convert("Category.EATING_OUT_Coffee", mocked_classifier)
+        assert result == "['EATING_OUT', 'Coffee']"
+
+    def test_travels_transportation_category(self, mocked_classifier):
+        result = self._convert(
+            "Category.TRAVELS_TRANSPORTATION_Rideshare", mocked_classifier
+        )
+        assert result == "['TRAVELS_TRANSPORTATION', 'Rideshare']"
+
+    def test_raises_for_unrecognised_label(self, mocked_classifier):
+        from src.transactions.classification import convert_to_category_list_str
+        with pytest.raises(ValueError, match="Could not find an appropriate category"):
+            convert_to_category_list_str({"label": "UNKNOWN_FORMAT", "score": 0.5})
+
+
+# ── classify_unknowns ─────────────────────────────────────────────────────────
+
+class TestClassifyUnknowns:
+    def test_classifies_all_unknown_transactions(
+        self, mocked_classifier, unknown_category_df
+    ):
+        mocked_classifier.return_value = [
+            {"label": "Category.SHOPPING_Groceries", "score": 0.95},
+            {"label": "Category.BILLS_SUBSCRIPTIONS_Streaming", "score": 0.88},
+        ]
+
+        from src.transactions.classification import classify_unknowns
+        result = classify_unknowns(unknown_category_df)
+
+        assert result.loc[0, "category"] == "['SHOPPING', 'Groceries']"
+        assert result.loc[1, "category"] == "['BILLS_SUBSCRIPTIONS', 'Streaming']"
+
+    def test_skips_already_categorised_rows(self, mocked_classifier):
+        """Rows with a known category must not be sent to the model."""
+        df = pd.DataFrame({
+            "date": ["2024-01-01", "2024-01-02"],
+            "name": ["WHOLE FOODS MARKET", "NETFLIX"],
+            "category": [
+                "['SHOPPING', 'Groceries']",   # already known
+                "['Unknown', 'Unknown']",       # needs classification
+            ],
+            "amount": [42.50, 12.99],
+        })
+
+        # Only one Unknown row → model is called with one item → returns one result
+        mocked_classifier.return_value = [
+            {"label": "Category.BILLS_SUBSCRIPTIONS_Streaming", "score": 0.88},
+        ]
+
+        from src.transactions.classification import classify_unknowns
+        result = classify_unknowns(df)
+
+        # Known row must be unchanged
+        assert result.loc[0, "category"] == "['SHOPPING', 'Groceries']"
+        # Unknown row gets classified
+        assert result.loc[1, "category"] == "['BILLS_SUBSCRIPTIONS', 'Streaming']"
+
+    def test_returns_unchanged_when_no_unknowns(
+        self, mocked_classifier, sample_plaid_df
+    ):
+        """When all transactions are already categorised the pipeline is never called."""
+        from src.transactions.classification import classify_unknowns
+        result = classify_unknowns(sample_plaid_df)
+
+        mocked_classifier.assert_not_called()
+        pd.testing.assert_frame_equal(result, sample_plaid_df)
+
+    def test_does_not_mutate_input_dataframe(
+        self, mocked_classifier, unknown_category_df
+    ):
+        mocked_classifier.return_value = [
+            {"label": "Category.SHOPPING_Groceries", "score": 0.9},
+            {"label": "Category.EATING_OUT_Coffee", "score": 0.85},
+        ]
+
+        original_categories = unknown_category_df["category"].tolist()
+
+        from src.transactions.classification import classify_unknowns
+        classify_unknowns(unknown_category_df)
+
+        # Input should not be modified in place
+        assert unknown_category_df["category"].tolist() == original_categories
+
+    def test_model_receives_only_unknown_transaction_names(self, mocked_classifier):
+        df = pd.DataFrame({
+            "name": ["WHOLE FOODS", "NETFLIX", "STARBUCKS"],
+            "category": [
+                "['SHOPPING', 'Groceries']",
+                "['Unknown', 'Unknown']",
+                "['Unknown', 'Unknown']",
+            ],
+            "amount": [42.50, 12.99, 5.75],
+        })
+        mocked_classifier.return_value = [
+            {"label": "Category.BILLS_SUBSCRIPTIONS_Streaming", "score": 0.9},
+            {"label": "Category.EATING_OUT_Coffee", "score": 0.85},
+        ]
+
+        from src.transactions.classification import classify_unknowns
+        classify_unknowns(df)
+
+        # The pipeline should be called with only the 2 unknown names, not all 3
+        call_args = mocked_classifier.call_args
+        names_passed = call_args.args[0]
+        assert "WHOLE FOODS" not in names_passed
+        assert "NETFLIX" in names_passed
+        assert "STARBUCKS" in names_passed
+
+
+# ── local_transaction_clf_wrapper ImportError handling ────────────────────────
+
+class TestLocalClfWrapperImportError:
+    def test_returns_df_unchanged_when_transformers_missing(
+        self, monkeypatch, sample_plaid_df
+    ):
+        """When classification.py cannot be imported the wrapper must not raise."""
+        # None in sys.modules causes ImportError on any attempt to import that module
+        monkeypatch.setitem(sys.modules, "src.transactions.classification", None)
+
+        from src.transactions.selection import local_transaction_clf_wrapper
+        result = local_transaction_clf_wrapper(sample_plaid_df)
+
+        pd.testing.assert_frame_equal(result, sample_plaid_df)
+
+    def test_prints_warning_when_transformers_missing(
+        self, monkeypatch, sample_plaid_df, capsys
+    ):
+        monkeypatch.setitem(sys.modules, "src.transactions.classification", None)
+
+        from src.transactions.selection import local_transaction_clf_wrapper
+        local_transaction_clf_wrapper(sample_plaid_df)
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "transformers" in captured.out.lower() or "classification" in captured.out.lower()

--- a/test/test_modifications.py
+++ b/test/test_modifications.py
@@ -16,6 +16,7 @@ def tmp_config(transformations=None, remove_transactions=None, custom_category_m
             transformations=transformations,
             remove_transactions=remove_transactions,
             custom_category_map=custom_category_map,
+            category_renaming_map={},
         )
     }
 

--- a/test/test_selection.py
+++ b/test/test_selection.py
@@ -1,0 +1,222 @@
+"""
+Tests for src/transactions/selection.py
+
+Covers:
+  - read_cached_transactions(): happy path, missing file, date column type
+  - maybe_pull_latest_transactions(): first run (no CSV), update of existing
+    data, skip when data is fresh, local-classification flag
+"""
+import json
+import os
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from test.conftest import SIMPLEFIN_API_RESPONSE
+
+import src.transactions.simplefin_transactions as sf_module
+from src.transactions.selection import (
+    maybe_pull_latest_transactions,
+    read_cached_transactions,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _setup_simplefin_mocks(monkeypatch, config: dict) -> MagicMock:
+    """Patch config and HTTP for a SimpleFin pull.  Returns the mock requests."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = SIMPLEFIN_API_RESPONSE
+
+    mock_requests = MagicMock()
+    mock_requests.get.return_value = mock_response
+
+    monkeypatch.setattr("src.transactions.selection.get_config", lambda: config)
+    monkeypatch.setattr(sf_module, "get_config", lambda: config)
+    monkeypatch.setattr(sf_module, "requests", mock_requests)
+
+    return mock_requests
+
+
+# ── read_cached_transactions ───────────────────────────────────────────────────
+
+class TestReadCachedTransactions:
+    def test_returns_dataframe_when_csv_exists(
+        self, tmp_path, sample_plaid_df, monkeypatch
+    ):
+        csv_path = str(tmp_path / "transactions.csv")
+        sample_plaid_df.to_csv(csv_path, index=False)
+        monkeypatch.setattr(
+            "src.transactions.selection.EXISTING_TRANSACTIONS_FILE", csv_path
+        )
+
+        result = read_cached_transactions()
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == len(sample_plaid_df)
+        assert set(result.columns) == set(sample_plaid_df.columns)
+
+    def test_raises_when_csv_missing(self, tmp_path, monkeypatch):
+        missing = str(tmp_path / "does_not_exist.csv")
+        monkeypatch.setattr(
+            "src.transactions.selection.EXISTING_TRANSACTIONS_FILE", missing
+        )
+
+        with pytest.raises(FileNotFoundError):
+            read_cached_transactions()
+
+    def test_date_column_is_string(self, tmp_path, sample_plaid_df, monkeypatch):
+        csv_path = str(tmp_path / "transactions.csv")
+        sample_plaid_df.to_csv(csv_path, index=False)
+        monkeypatch.setattr(
+            "src.transactions.selection.EXISTING_TRANSACTIONS_FILE", csv_path
+        )
+
+        result = read_cached_transactions()
+
+        assert result["date"].apply(lambda x: isinstance(x, str)).all()
+
+    def test_round_trips_all_rows(self, tmp_path, sample_plaid_df, monkeypatch):
+        csv_path = str(tmp_path / "transactions.csv")
+        sample_plaid_df.to_csv(csv_path, index=False)
+        monkeypatch.setattr(
+            "src.transactions.selection.EXISTING_TRANSACTIONS_FILE", csv_path
+        )
+
+        result = read_cached_transactions()
+
+        assert result["amount"].tolist() == sample_plaid_df["amount"].tolist()
+        assert result["name"].tolist() == sample_plaid_df["name"].tolist()
+
+
+# ── maybe_pull_latest_transactions ────────────────────────────────────────────
+
+class TestMaybePullLatestTransactions:
+    def test_creates_csv_on_first_run(
+        self, patched_data_dir, simplefin_config, monkeypatch
+    ):
+        txn_file, _ = patched_data_dir
+        _setup_simplefin_mocks(monkeypatch, simplefin_config)
+
+        result = maybe_pull_latest_transactions()
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+        assert os.path.exists(txn_file), "CSV should be written on first run"
+
+    def test_saved_csv_has_required_columns(
+        self, patched_data_dir, simplefin_config, monkeypatch
+    ):
+        txn_file, _ = patched_data_dir
+        _setup_simplefin_mocks(monkeypatch, simplefin_config)
+
+        maybe_pull_latest_transactions()
+
+        saved = pd.read_csv(txn_file)
+        for col in ("date", "name", "amount", "category"):
+            assert col in saved.columns, f"Expected column '{col}' in saved CSV"
+
+    def test_writes_pull_info_file(
+        self, patched_data_dir, simplefin_config, monkeypatch
+    ):
+        _, pull_info_file = patched_data_dir
+        _setup_simplefin_mocks(monkeypatch, simplefin_config)
+
+        maybe_pull_latest_transactions()
+
+        assert os.path.exists(pull_info_file)
+        with open(pull_info_file) as f:
+            info = json.load(f)
+        assert "latest_pull" in info
+        assert info["success"] is True
+
+    def test_updates_existing_csv(
+        self, patched_data_dir, simplefin_config, monkeypatch
+    ):
+        txn_file, _ = patched_data_dir
+        # The deduplication logic in maybe_pull_latest_transactions keeps rows
+        # with date < (max_date - 10 days) and replaces the rest with fresh API
+        # data.  Concretely, with latest_date="2023-06-15" and GRACE=10 days,
+        # start_date becomes "2023-06-05".  The two Jan rows are preserved; the
+        # Jun row is replaced by the 2 mock API transactions.
+        old_df = pd.DataFrame({
+            "date": ["2023-01-01", "2023-01-02", "2023-06-15"],
+            "name": ["OLD_A", "OLD_B", "OLD_C"],
+            "merchant_name": ["M1", "M2", "M3"],
+            "category": ["['X', 'Y']", "['X', 'Y']", "['X', 'Y']"],
+            "payment_channel": ["online", "online", "online"],
+            "amount": [10.0, 20.0, 30.0],
+        })
+        old_df.to_csv(txn_file, index=False)
+        _setup_simplefin_mocks(monkeypatch, simplefin_config)
+
+        result = maybe_pull_latest_transactions()
+
+        # 2 preserved old rows + 2 new API rows = 4, which is more than the 3 original
+        assert len(result) == 4
+        assert {"OLD_A", "OLD_B"}.issubset(set(result["name"]))
+
+    def test_skips_api_call_when_data_is_fresh(
+        self, patched_data_dir, simplefin_config, sample_plaid_df, monkeypatch
+    ):
+        txn_file, pull_info_file = patched_data_dir
+        sample_plaid_df.to_csv(txn_file, index=False)
+
+        # Record a pull that happened moments ago
+        with open(pull_info_file, "w") as f:
+            json.dump(
+                {
+                    "latest_pull": datetime.now().isoformat(),
+                    "latest_transaction_date": "2024-01-15",
+                    "method": "simple_fin",
+                    "success": True,
+                },
+                f,
+            )
+
+        mock_requests = _setup_simplefin_mocks(monkeypatch, simplefin_config)
+
+        result = maybe_pull_latest_transactions()
+
+        mock_requests.get.assert_not_called()
+        assert len(result) == len(sample_plaid_df)
+
+    def test_calls_local_classifier_when_enabled(
+        self, patched_data_dir, simplefin_config, monkeypatch
+    ):
+        _, _ = patched_data_dir
+        config_with_clf = {
+            **simplefin_config,
+            "settings": {
+                **simplefin_config["settings"],
+                "use_local_categorization": True,
+            },
+        }
+        _setup_simplefin_mocks(monkeypatch, config_with_clf)
+
+        mock_clf = MagicMock(side_effect=lambda df: df)  # identity — returns df unchanged
+        monkeypatch.setattr(
+            "src.transactions.selection.local_transaction_clf_wrapper", mock_clf
+        )
+
+        maybe_pull_latest_transactions()
+
+        mock_clf.assert_called_once()
+
+    def test_does_not_call_local_classifier_when_disabled(
+        self, patched_data_dir, simplefin_config, monkeypatch
+    ):
+        _, _ = patched_data_dir
+        # simplefin_config already has use_local_categorization=False
+        _setup_simplefin_mocks(monkeypatch, simplefin_config)
+
+        mock_clf = MagicMock(side_effect=lambda df: df)
+        monkeypatch.setattr(
+            "src.transactions.selection.local_transaction_clf_wrapper", mock_clf
+        )
+
+        maybe_pull_latest_transactions()
+
+        mock_clf.assert_not_called()

--- a/test/test_simplefin.py
+++ b/test/test_simplefin.py
@@ -1,0 +1,187 @@
+"""
+Tests for src/transactions/simplefin_transactions.py
+
+Covers:
+  - request_transactions_raw(): API call, auth forwarding, account-info merge
+  - get_transactions_df(): amount negation, date format, field mapping,
+    default Unknown category assignment
+"""
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from test.conftest import SIMPLEFIN_API_RESPONSE
+
+import src.transactions.simplefin_transactions as sf_module
+from src.transactions.simplefin_transactions import (
+    get_transactions_df,
+    request_transactions_raw,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _mock_http(monkeypatch, config, response_body=SIMPLEFIN_API_RESPONSE):
+    """Patch requests and get_config in simplefin_transactions."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_body
+
+    mock_requests = MagicMock()
+    mock_requests.get.return_value = mock_response
+
+    monkeypatch.setattr(sf_module, "requests", mock_requests)
+    monkeypatch.setattr(sf_module, "get_config", lambda: config)
+
+    return mock_requests
+
+
+# ── request_transactions_raw ──────────────────────────────────────────────────
+
+class TestRequestTransactionsRaw:
+    def test_calls_simplefin_url(self, simplefin_config, monkeypatch):
+        mock_requests = _mock_http(monkeypatch, simplefin_config)
+
+        request_transactions_raw("2024-01-01", "2024-01-31")
+
+        mock_requests.get.assert_called_once()
+        call_url = mock_requests.get.call_args.args[0]
+        assert "simplefin" in call_url
+
+    def test_passes_auth_from_config(self, simplefin_config, monkeypatch):
+        mock_requests = _mock_http(monkeypatch, simplefin_config)
+
+        request_transactions_raw("2024-01-01", "2024-01-31")
+
+        call_kwargs = mock_requests.get.call_args.kwargs
+        # simplefin_config["simplefin_auth"] = "user:password"
+        assert call_kwargs["auth"] == ("user", "password")
+
+    def test_passes_start_date_as_epoch(self, simplefin_config, monkeypatch):
+        mock_requests = _mock_http(monkeypatch, simplefin_config)
+
+        request_transactions_raw("2024-01-01", "2024-01-31")
+
+        call_kwargs = mock_requests.get.call_args.kwargs
+        assert "start-date" in call_kwargs["params"]
+        assert isinstance(call_kwargs["params"]["start-date"], int)
+
+    def test_returns_all_transactions_as_dataframe(
+        self, simplefin_config, monkeypatch
+    ):
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = request_transactions_raw("2024-01-01", "2024-01-31")
+
+        assert isinstance(result, pd.DataFrame)
+        # SIMPLEFIN_API_RESPONSE has 1 account with 2 transactions
+        assert len(result) == 2
+
+    def test_merges_account_id_into_each_row(self, simplefin_config, monkeypatch):
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = request_transactions_raw("2024-01-01", "2024-01-31")
+
+        assert "account_id" in result.columns
+        assert (result["account_id"] == "acct_001").all()
+
+    def test_omits_end_date_param_when_none(self, simplefin_config, monkeypatch):
+        mock_requests = _mock_http(monkeypatch, simplefin_config)
+
+        request_transactions_raw("2024-01-01")  # no end_date
+
+        call_kwargs = mock_requests.get.call_args.kwargs
+        assert "end-date" not in call_kwargs["params"]
+
+
+# ── get_transactions_df ───────────────────────────────────────────────────────
+
+class TestGetTransactionsDf:
+    def test_negates_simplefin_amounts(self, simplefin_config, monkeypatch):
+        """SimpleFin uses negative for debits; Plaid convention is positive."""
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = get_transactions_df("2024-01-01")
+
+        # Source amounts are "-42.50" and "-12.99"; expect positive floats
+        assert (result["amount"] > 0).all()
+        assert set(round(a, 2) for a in result["amount"]) == {42.50, 12.99}
+
+    def test_date_is_ten_char_iso_string(self, simplefin_config, monkeypatch):
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = get_transactions_df("2024-01-01")
+
+        assert result["date"].apply(lambda d: len(d) == 10 and d[4] == "-").all()
+
+    def test_maps_description_to_name(self, simplefin_config, monkeypatch):
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = get_transactions_df("2024-01-01")
+
+        assert set(result["name"]) == {"WHOLE FOODS MARKET", "NETFLIX"}
+
+    def test_maps_payee_to_merchant_name(self, simplefin_config, monkeypatch):
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = get_transactions_df("2024-01-01")
+
+        assert set(result["merchant_name"]) == {"Whole Foods", "Netflix"}
+
+    def test_category_defaults_to_unknown(self, simplefin_config, monkeypatch):
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = get_transactions_df("2024-01-01")
+
+        assert all(result["category"].apply(lambda c: c == ["Unknown", "Unknown"]))
+
+    def test_payment_channel_is_unknown(self, simplefin_config, monkeypatch):
+        _mock_http(monkeypatch, simplefin_config)
+
+        result = get_transactions_df("2024-01-01")
+
+        assert (result["payment_channel"] == "unknown").all()
+
+    def test_multiple_accounts_are_combined(self, simplefin_config, monkeypatch):
+        two_account_response = {
+            "accounts": [
+                {
+                    "id": "acct_001",
+                    "name": "Checking",
+                    "currency": "USD",
+                    "balance": "1000.00",
+                    "balance-date": 1704153600,
+                    "transactions": [
+                        {
+                            "id": "txn_A",
+                            "amount": "-10.00",
+                            "description": "Shop A",
+                            "payee": "Payee A",
+                            "transacted_at": 1704110400,
+                        }
+                    ],
+                },
+                {
+                    "id": "acct_002",
+                    "name": "Savings",
+                    "currency": "USD",
+                    "balance": "5000.00",
+                    "balance-date": 1704153600,
+                    "transactions": [
+                        {
+                            "id": "txn_B",
+                            "amount": "-20.00",
+                            "description": "Shop B",
+                            "payee": "Payee B",
+                            "transacted_at": 1704110400,
+                        }
+                    ],
+                },
+            ]
+        }
+        _mock_http(monkeypatch, simplefin_config, two_account_response)
+
+        result = get_transactions_df("2024-01-01")
+
+        assert len(result) == 2
+        assert set(result["account_id"]) == {"acct_001", "acct_002"}

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,3 @@
+# Requirements for running the test suite.
+# Install with: pip install -r test_requirements.txt
+pytest>=7.0.0


### PR DESCRIPTION
## What changed

### New files
- `Dockerfile` + `.dockerignore` — containerize the Streamlit app (Python 3.11-slim, port 8080)
- `cloud_requirements.txt` — minimal, Linux-compatible dependency set for the Docker image (strips macOS-only packages and unused Jupyter tooling from dashboard_requirements.txt)
- `cloud/setup.sh` — one-time GCP infrastructure setup (Artifact Registry, GCS bucket, service account, IAM, Secrets)
- `cloud/deploy.sh` — build → push → deploy Cloud Run service + Job + Cloud Scheduler trigger
- `cloud/service.yaml` — Cloud Run service definition with GCS FUSE volume mount so the transactions CSV and config.json persist across container restarts
- `cloud/job.yaml` — Cloud Run Job definition for the nightly background transaction update
- `scripts/update_transactions.py` — standalone entrypoint for the update job (used by the Cloud Run Job)

### Modified files
- `scripts/st_dashboard.py`
  - Add password-based auth (`check_password()`). No-op locally (no APP_PASSWORD env var). Reads password from Cloud Run secret.
  - Add sidebar config editor (`_render_config_editor()`) — edits config.json in place (GCS-backed in cloud), saves and reloads in one click.
  - Update `@st.cache` → `@st.cache_data` for compatibility with Streamlit ≥1.28.
- `src/utils.py`
  - `get_config()` reads path from `CONFIG_PATH` env var (defaults to `./config.json` for local dev)
  - Add `get_config_path()` helper
  - Add `reload_config()` to clear in-memory cache after config editor saves
- `src/transactions/selection.py`
  - `local_transaction_clf_wrapper()` now catches `ImportError` and emits a warning instead of crashing when torch/transformers are not installed (they are excluded from cloud_requirements.txt by default to keep the image small)

## Architecture

```
GCS bucket (gs://<project>-budget-data/)
  ├── all_transactions.csv        ← written by update job, read by dashboard
  ├── latest_pull_info.json       ← update cadence tracking
  └── config.json                 ← editable via dashboard sidebar

Cloud Run Service (budget-dashboard)   ← serves Streamlit, mounts bucket via FUSE
Cloud Run Job    (budget-update-transactions) ← runs nightly, mounts same bucket
Cloud Scheduler  ← triggers the job at 06:00 daily
Secret Manager   ← SIMPLEFIN_AUTH, APP_PASSWORD
```